### PR TITLE
Fix utils_test imports

### DIFF
--- a/utils_test.py
+++ b/utils_test.py
@@ -1,18 +1,18 @@
 import asyncio
-from utils import fetch_pairs, filter_pairs, format_pair_message
+
+from utils import fetch_dex_data, filter_signals, format_signals
 
 async def main():
     print("📡 Fetching data from DEXScreener...")
-    pairs = await fetch_pairs()
+    pairs = await fetch_dex_data()
     print(f"✅ Total pairs fetched: {len(pairs)}")
 
-    filtered = filter_pairs(pairs)
+    filtered = filter_signals(pairs)
     print(f"🧪 Pairs after filtering: {len(filtered)}")
 
-    print("\n📊 Example formatted output:")
-    for pair in filtered[:3]:
-        msg = format_pair_message(pair, include_meta=True)
-        print("\n" + msg)
+    print("\n📊 Example formatted output:\n")
+    output = format_signals(filtered[:3])
+    print(output)
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- fix imports in utils_test to match utils module
- call new utility functions to fetch, filter and format

## Testing
- `python utils_test.py` *(fails to fetch data: 404 but script runs)*

------
https://chatgpt.com/codex/tasks/task_e_688b703c7dbc8328b38852f64207265c