### PR TITLE
Fix scheduler signal helpers

### DIFF
--- a/dex/screener.py
+++ b/dex/screener.py
@@ -3,9 +3,14 @@
 import httpx
 import logging
 from config import MIN_VOLUME, MIN_LIQUIDITY, MIN_PRICE_CHANGE
-from alerts.utils import format_signal_message
+
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Fetch and filter data from the DEXScreener API.  Helper utilities here are
+# used by both the command handlers and the scheduled jobs.
+# ---------------------------------------------------------------------------
 
 DEXSCREENER_API = "https://api.dexscreener.com/latest/dex/pairs/solana"
 
@@ -33,6 +38,45 @@ def filter_signals(pairs: list) -> list:
         except Exception as e:
             logger.warning(f"[dex/screener] Skipping malformed pair: {e}")
     return filtered
+
+def format_signal_message(pair: dict) -> str:
+    """Return a markdown formatted message for a single trading pair."""
+    base = pair.get("baseToken", {}).get("symbol", "")
+    quote = pair.get("quoteToken", {}).get("symbol", "")
+    name = f"{base}/{quote}"
+    price = float(pair.get("priceUsd", 0))
+    change = float(pair.get("priceChange", {}).get("h1", 0))
+    volume = float(pair.get("volume", {}).get("h24", 0))
+    liquidity = float(pair.get("liquidity", {}).get("usd", 0))
+    url = pair.get("url", "")
+    emoji = "📈" if change > 0 else "📉"
+
+    return (
+        f"{emoji} [{name}]({url})\n"
+        f"💰 Price: `${price:.6f}`\n"
+        f"💹 1h Change: `{change:.2f}%`\n"
+        f"📊 Volume 24h: `${volume:,.0f}`\n"
+        f"🔒 Liquidity: `${liquidity:,.0f}`"
+    )
+
+async def get_filtered_signals(limit: int = 5) -> list:
+    """Fetch and filter pairs, returning up to ``limit`` results."""
+    raw_pairs = await fetch_dex_data()
+    return filter_signals(raw_pairs)[:limit]
+
+def format_signals_message(pairs: list, vip: bool = False) -> str:
+    """Compose a multi-line message from filtered pairs."""
+    if not pairs:
+        return "⚠️ No high-quality signals found right now."
+
+    header = "💎 *VIP SIGNALS*\n\n" if vip else "📊 *Top Crypto Pairs Today*\n\n"
+    body = "\n\n".join(format_signal_message(p) for p in pairs)
+    footer = (
+        "🔒 *Private signals for VIP members only.*"
+        if vip
+        else "💎 Want more? [Join VIP](https://t.me/+sR2qa2jnr6o5MDk0) for exclusive updates!"
+    )
+    return header + body + "\n\n" + footer
 
 async def get_filtered_signal_messages():
     raw_pairs = await fetch_dex_data()


### PR DESCRIPTION
## Summary
- implement signal formatting helpers in `dex/screener`
- ensure `publish_signals_job` uses these helpers

## Testing
- `pip install -r requirements.txt`
- `python utils_test.py` *(fails: cannot import name 'fetch_pairs')*

------
https://chatgpt.com/codex/tasks/task_e_688b703bab288328a4b752fe6e717b24