### PR TITLE
Fix unused variable in is_legit_token

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -24,7 +24,6 @@ async def fetch_dex_data():
 def is_legit_token(pair):
     """Simulate anti-scam heuristics (can be enhanced with on-chain data)"""
     try:
-        base = pair.get("baseToken", {})
         tax = pair.get("txns", {}).get("h1", {}).get("buys", 0) + pair.get("txns", {}).get("h1", {}).get("sells", 0)
         renounced = pair.get("pairCreatedAt", 0) > 0  # Placeholder for renounce check
         locked = pair.get("liquidity", {}).get("locked", False)  # Placeholder


### PR DESCRIPTION
## Summary
- remove `base` variable from `is_legit_token`

## Testing
- `python -m py_compile utils.py`
- `pytest -q` *(fails: ImportError in utils_test)*

------
https://chatgpt.com/codex/tasks/task_e_688b70419c708328be5d81c4800bda23