### PR TITLE
Improve API error handling

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -8,17 +8,24 @@ logger = logging.getLogger(__name__)
 
 
 async def fetch_dex_data():
-    """Fetch top Solana pairs from DEXScreener"""
+    """Fetch top Solana pairs from DEXScreener with basic retries."""
     url = "https://api.dexscreener.com/latest/dex/pairs/solana"
-    try:
-        async with httpx.AsyncClient(timeout=10) as client:
-            response = await client.get(url)
-            response.raise_for_status()
-            data = response.json()
-            return data.get("pairs", [])
-    except Exception as e:
-        logger.error(f"Error fetching DEX data: {e}")
-        return []
+    for attempt in range(3):
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                response = await client.get(url)
+                if response.is_error:
+                    logger.warning(
+                        "DEXScreener returned %s on attempt %s",
+                        response.status_code,
+                        attempt + 1,
+                    )
+                    response.raise_for_status()
+                data = response.json()
+                return data.get("pairs", [])
+        except Exception as e:
+            logger.error("Error fetching DEX data: %s", e)
+    return []
 
 
 def is_legit_token(pair):


### PR DESCRIPTION
## Summary
- use `filter_signals` in alerts module
- add error handling/retries for DEXScreener API

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python utils_test.py`

------
https://chatgpt.com/codex/tasks/task_e_688bb16d61448328a21266a1645e47f8