### PR TITLE
Finalize scheduler utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# satoshi_bot
-Telegram bot for crypto signals integrated with TradingView via webhook.
+# Satoshi Signal Bot
+
+Satoshi Signal Bot is a Telegram bot that publishes crypto trading signals fetched from DEXScreener.  
+Signals are filtered using basic heuristics (volume, liquidity, price change and basic scam checks) and posted to separate Telegram channels for VIP and Public users.
+
+## Features
+
+- **Python 3.11** with `python-telegram-bot` job queue
+- Periodic background tasks for VIP (15 min) and public (8h) channels
+- Markdown formatted messages with links to DEXScreener
+- Basic anti scam heuristics
+- Configurable via `.env` and `config.py`
+
+## Usage
+
+1. Install requirements
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Create a `.env` file with `BOT_TOKEN` and any other credentials.
+3. Run the bot
+
+```bash
+python bot.py
+```
+
+## Testing helpers
+
+`utils_test.py` can be executed to verify API connectivity and message formatting.

--- a/dex/screener.py
+++ b/dex/screener.py
@@ -3,7 +3,7 @@
 import httpx
 import logging
 from config import MIN_VOLUME, MIN_LIQUIDITY, MIN_PRICE_CHANGE
-from utils import format_pair_message, format_signals
+from utils import format_pair_message, format_signals, is_legit_token
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,12 @@ def filter_signals(pairs: list) -> list:
             liquidity = float(pair.get("liquidity", {}).get("usd", 0))
             price_change = float(pair.get("priceChange", {}).get("h1", 0))
 
-            if volume >= MIN_VOLUME and liquidity >= MIN_LIQUIDITY and abs(price_change) >= MIN_PRICE_CHANGE:
+            if (
+                volume >= MIN_VOLUME
+                and liquidity >= MIN_LIQUIDITY
+                and abs(price_change) >= MIN_PRICE_CHANGE
+                and is_legit_token(pair)
+            ):
                 filtered.append(pair)
         except Exception as e:
             logger.warning(f"[dex/screener] Skipping malformed pair: {e}")

--- a/jobs/scheduler.py
+++ b/jobs/scheduler.py
@@ -2,33 +2,16 @@
 
 import logging
 from telegram.ext import ContextTypes
-from dex.screener import get_filtered_signals, format_signals_message
 from config import VIP_CHANNEL_ID, PUBLIC_CHANNEL_ID
+from scheduler.publisher import publish_job
 
 logger = logging.getLogger(__name__)
 
 
 async def publish_signals_job(context: ContextTypes.DEFAULT_TYPE):
+    """Wrapper that delegates publishing to :func:`scheduler.publisher.publish_job`."""
     try:
-        # Pobierz ID kanału z kontekstu zadania
-        channel_id = context.job.data
-
-        # Pobierz dane i sformatuj wiadomość
-        signals = await get_filtered_signals()
-        if not signals:
-            logger.info(f"Brak sygnałów spełniających kryteria dla {channel_id}")
-            return
-
-        message = format_signals_message(signals, vip=(channel_id == VIP_CHANNEL_ID))
-
-        await context.bot.send_message(
-            chat_id=channel_id,
-            text=message,
-            parse_mode="Markdown",
-            disable_web_page_preview=True
-        )
-        logger.info(f"Wysłano sygnały do kanału {channel_id}")
-
+        await publish_job(context)
     except Exception as e:
         logger.error(f"Błąd podczas publikacji sygnałów: {e}")
 

--- a/scheduler/publisher.py
+++ b/scheduler/publisher.py
@@ -1,1 +1,34 @@
+"""Background publishing utilities for Telegram alerts."""
 
+import logging
+from telegram.ext import ContextTypes
+from dex.screener import get_filtered_signals, format_signals_message
+from config import VIP_CHANNEL_ID
+
+logger = logging.getLogger(__name__)
+
+
+async def build_message(vip: bool) -> str:
+    """Fetch pairs from DEXScreener and format them for Telegram."""
+    pairs = await get_filtered_signals()
+    return format_signals_message(pairs, vip)
+
+
+async def publish_job(context: ContextTypes.DEFAULT_TYPE) -> None:
+    """JobQueue callback to publish signals to a channel."""
+    try:
+        channel_id = context.job.data
+        vip = channel_id == VIP_CHANNEL_ID
+        message = await build_message(vip)
+        if not message:
+            logger.info("No message generated for %s", channel_id)
+            return
+        await context.bot.send_message(
+            chat_id=channel_id,
+            text=message,
+            parse_mode="Markdown",
+            disable_web_page_preview=True,
+        )
+        logger.info("Signals published to %s", channel_id)
+    except Exception as exc:
+        logger.error("Publishing job failed: %s", exc)


### PR DESCRIPTION
## Summary
- add README with usage instructions
- implement telegram publishing utilities under `scheduler/`
- route `jobs/scheduler` through new publisher
- use scam checks when filtering pairs
- provide API failover in utility fetcher

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python utils_test.py` *(fails to fetch real data, returns 0 pairs)*

------
https://chatgpt.com/codex/tasks/task_e_688bec6566548328bfce34bc8b713120