### PR TITLE
Fix env variable loading and cleanup warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Signals are filtered using basic heuristics (volume, liquidity, price change and
 pip install -r requirements.txt
 ```
 
-2. Create a `.env` file with `BOT_TOKEN` and any other credentials.
+2. Create a `.env` file with `BOT_TOKEN` (or `TELEGRAM_TOKEN`) and any other credentials.
 3. Run the bot
 
 ```bash

--- a/bot.py
+++ b/bot.py
@@ -15,7 +15,7 @@ from config import VIP_CHANNEL_ID, PUBLIC_CHANNEL_ID
 
 # Load environment variables
 load_dotenv()
-BOT_TOKEN = os.getenv("BOT_TOKEN")
+BOT_TOKEN = os.getenv("BOT_TOKEN") or os.getenv("TELEGRAM_TOKEN")
 
 # Configure logging
 logging.basicConfig(

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ import os
 
 # Wczytaj zmienne środowiskowe
 load_dotenv()
-TOKEN = os.getenv("BOT_TOKEN")
+TOKEN = os.getenv("BOT_TOKEN") or os.getenv("TELEGRAM_TOKEN")
 
 # Konfiguracja logowania
 logging.basicConfig(

--- a/scam_checks/detector.py
+++ b/scam_checks/detector.py
@@ -1,6 +1,5 @@
 # === scam_checks/detector.py ===
 
-import httpx
 
 async def is_renounced(pair):
     # TODO: Replace with actual logic based on token contract audit or blockchain call

--- a/utils.py
+++ b/utils.py
@@ -36,13 +36,12 @@ async def fetch_dex_data():
 def is_legit_token(pair):
     """Simulate anti-scam heuristics (can be enhanced with on-chain data)"""
     try:
-        base = pair.get("baseToken", {})
         tax = pair.get("txns", {}).get("h1", {}).get("buys", 0) + pair.get("txns", {}).get("h1", {}).get("sells", 0)
         renounced = pair.get("pairCreatedAt", 0) > 0  # Placeholder for renounce check
         locked = pair.get("liquidity", {}).get("locked", False)  # Placeholder
 
         return renounced and locked and tax >= 5
-    except:
+    except Exception:
         return False
 
 


### PR DESCRIPTION
## Summary
- allow using TELEGRAM_TOKEN if BOT_TOKEN is unset
- document TELEGRAM_TOKEN in README
- remove unused variable and improve exception handling
- drop unused import in scam checker

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bf39efe7083289e7b9a1f7e8768bd