### PR TITLE
Fix Telegram polling conflict by using webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ pip install -r requirements.txt
 ```
 
 2. Create a `.env` file with `BOT_TOKEN` (or `TELEGRAM_TOKEN`) and any other credentials.
+   When deploying on Render, set `WEBHOOK_URL` to your service URL to enable webhook mode and avoid polling conflicts.
 3. Run the bot
 
 ```bash

--- a/bot.py
+++ b/bot.py
@@ -57,7 +57,21 @@ def main():
     )
 
     logger.info("Bot started. Use Ctrl+C to stop.")
-    application.run_polling(allowed_updates=None)
+
+    webhook_url = os.getenv("WEBHOOK_URL")
+    if webhook_url:
+        path = f"/{BOT_TOKEN}"
+        listen_port = int(os.getenv("PORT", 8443))
+        logger.info("Starting webhook at %s", webhook_url)
+        application.run_webhook(
+            listen="0.0.0.0",
+            port=listen_port,
+            url_path=path,
+            webhook_url=f"{webhook_url}{path}",
+            allowed_updates=None,
+        )
+    else:
+        application.run_polling(allowed_updates=None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add optional webhook support in `bot.py` to avoid polling conflicts
- document new `WEBHOOK_URL` variable in README

## Testing
- `python utils_test.py`

------
https://chatgpt.com/codex/tasks/task_e_688bf654f954832894c24b7e812d0f08