### PR TITLE
Validate webhook URL and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ pip install -r requirements.txt
 
 2. Create a `.env` file with `BOT_TOKEN` (or `TELEGRAM_TOKEN`) and any other credentials.
    When deploying on Render, set `WEBHOOK_URL` to your service URL to enable webhook mode and avoid polling conflicts.
+   The URL must include protocol and domain; invalid values are ignored and the bot falls back to polling.
 3. Run the bot
 
 ```bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,13 @@
+from bot import _is_valid_webhook
+
+
+def test_valid_urls():
+    assert _is_valid_webhook("https://example.com")
+    assert _is_valid_webhook("http://example.com:8080")
+
+
+def test_invalid_urls():
+    assert not _is_valid_webhook("ftp://example.com")
+    assert not _is_valid_webhook("https://")
+    assert not _is_valid_webhook("https://example.com:abc")
+    assert not _is_valid_webhook("not a url")


### PR DESCRIPTION
## Summary
- validate and parse `WEBHOOK_URL` before enabling webhook mode
- document webhook requirements in README
- add unit tests for webhook URL validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68917c6a775c83289d9d8e944daca0da